### PR TITLE
Add Fortran modules for emissions, efficiency, and trade-offs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
-  "tasks": {
-    "build": "No build commands are necessary."
-  }
+  "name": "FortranDev",
+  "image": "mcr.microsoft.com/devcontainers/python",
+  "features": {
+    "ghcr.io/devcontainers/features/fortran:1": {}
+  },
+  "postCreateCommand": "pip install numpy && f2py -c -m emissions fortran/calculate_emissions.f90 && f2py -c -m efficiency fortran/optimize_fuel_efficiency.f90 && f2py -c -m tradeoffs fortran/analyze_trade_offs.f90"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Fortran CI Pipeline
+
+on: [push, pull_request]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y gfortran python3-pip
+
+    - name: Install Python packages
+      run: pip install numpy
+
+    - name: Compile Fortran modules with f2py
+      run: |
+        f2py -c -m emissions fortran/calculate_emissions.f90
+        f2py -c -m efficiency fortran/optimize_fuel_efficiency.f90
+        f2py -c -m tradeoffs fortran/analyze_trade_offs.f90
+
+    - name: Run Python tests (add your test script)
+      run: python3 tests/run_tests.py

--- a/fortran/analyze_trade_offs.f90
+++ b/fortran/analyze_trade_offs.f90
@@ -1,0 +1,16 @@
+module tradeoffs_module
+  implicit none
+contains
+  function analyze_trade_offs(emission, efficiency) result(score)
+    ! Combines emission and efficiency into an environmental trade-off score
+
+    real(8), intent(in) :: emission, efficiency
+    real(8) :: score
+
+    if (emission <= 0.0d0 .or. efficiency <= 0.0d0) then
+      score = -1.0d0
+    else
+      score = efficiency / emission
+    end if
+  end function analyze_trade_offs
+end module tradeoffs_module

--- a/fortran/calculate_emissions.f90
+++ b/fortran/calculate_emissions.f90
@@ -1,0 +1,21 @@
+module emissions_module
+  implicit none
+contains
+  function calculate_emissions(tech_index, fuel_burn) result(co2_emission)
+    ! Input: propulsion tech index and fuel burned (kg)
+    ! Output: CO₂ emissions (kg)
+
+    integer, intent(in) :: tech_index
+    real(8), intent(in) :: fuel_burn
+    real(8) :: co2_emission
+    real(8), dimension(3) :: emission_factors
+
+    emission_factors = (/ 3.15d0, 2.85d0, 0.0d0 /) ! Example: Jet A, LH2, Electric
+
+    if (tech_index < 1 .or. tech_index > size(emission_factors)) then
+      co2_emission = -1.0d0
+    else
+      co2_emission = emission_factors(tech_index) * fuel_burn
+    end if
+  end function calculate_emissions
+end module emissions_module

--- a/fortran/optimize_fuel_efficiency.f90
+++ b/fortran/optimize_fuel_efficiency.f90
@@ -1,0 +1,17 @@
+module efficiency_module
+  implicit none
+contains
+  function optimize_fuel_efficiency(thrust, drag, sfc) result(efficiency)
+    ! Input: thrust (N), drag (N), sfc (kg/Nh)
+    ! Output: fuel efficiency (km/kg)
+
+    real(8), intent(in) :: thrust, drag, sfc
+    real(8) :: efficiency
+
+    if (drag <= 0.0d0 .or. sfc <= 0.0d0) then
+      efficiency = -1.0d0
+    else
+      efficiency = thrust / (drag * sfc)
+    end if
+  end function optimize_fuel_efficiency
+end module efficiency_module

--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+import emissions
+import efficiency
+import tradeoffs
+
+co2 = emissions.calculate_emissions(1, 500.0)
+eff = efficiency.optimize_fuel_efficiency(12000.0, 8000.0, 0.6)
+score = tradeoffs.analyze_trade_offs(co2, eff)
+
+print(f"CO2 Emission: {co2:.2f} kg")
+print(f"Efficiency: {eff:.2f} km/kg")
+print(f"Trade-off Score: {score:.4f}")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,28 @@
+import emissions
+import efficiency
+import tradeoffs
+
+def test_calculate_emissions():
+    assert emissions.calculate_emissions(1, 500.0) == 1575.0
+    assert emissions.calculate_emissions(2, 500.0) == 1425.0
+    assert emissions.calculate_emissions(3, 500.0) == 0.0
+    assert emissions.calculate_emissions(0, 500.0) == -1.0
+    assert emissions.calculate_emissions(4, 500.0) == -1.0
+
+def test_optimize_fuel_efficiency():
+    assert efficiency.optimize_fuel_efficiency(12000.0, 8000.0, 0.6) == 2.5
+    assert efficiency.optimize_fuel_efficiency(12000.0, 0.0, 0.6) == -1.0
+    assert efficiency.optimize_fuel_efficiency(12000.0, 8000.0, 0.0) == -1.0
+    assert efficiency.optimize_fuel_efficiency(12000.0, -8000.0, 0.6) == -1.0
+
+def test_analyze_trade_offs():
+    assert tradeoffs.analyze_trade_offs(1575.0, 2.5) == 0.0015873015873015873
+    assert tradeoffs.analyze_trade_offs(0.0, 2.5) == -1.0
+    assert tradeoffs.analyze_trade_offs(1575.0, 0.0) == -1.0
+    assert tradeoffs.analyze_trade_offs(-1575.0, 2.5) == -1.0
+
+if __name__ == "__main__":
+    test_calculate_emissions()
+    test_optimize_fuel_efficiency()
+    test_analyze_trade_offs()
+    print("All tests passed.")


### PR DESCRIPTION
Add Fortran modules for emissions, efficiency, and trade-offs calculations, and integrate them into CI/CD pipeline and devcontainer.

* **Fortran Modules**
  - Add `fortran/calculate_emissions.f90` to define `emissions_module` with `calculate_emissions` function to calculate CO₂ emissions based on `tech_index` and `fuel_burn`.
  - Add `fortran/optimize_fuel_efficiency.f90` to define `efficiency_module` with `optimize_fuel_efficiency` function to calculate fuel efficiency based on `thrust`, `drag`, and `sfc`.
  - Add `fortran/analyze_trade_offs.f90` to define `tradeoffs_module` with `analyze_trade_offs` function to calculate environmental trade-off score based on `emission` and `efficiency`.

* **CI/CD Pipeline**
  - Add `.github/workflows/ci.yml` to define CI pipeline for Fortran modules, install dependencies, compile Fortran modules with `f2py`, and run Python tests.

* **Devcontainer**
  - Modify `.devcontainer/devcontainer.json` to add Fortran feature and postCreateCommand to install dependencies and compile Fortran modules.

* **Python Integration**
  - Add `main.py` to import `emissions`, `efficiency`, and `tradeoffs` modules, calculate CO₂ emission, efficiency, and trade-off score, and print results.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Gaia-Q-Space/.github/pull/2?shareId=d9311c28-4213-43e9-a6b9-e663b62b6e92).