### PR TITLE
Add chardet encoding detection and conversion to UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,19 @@ To run the tests using `pytest`, follow these steps:
    ```
    pytest
    ```
+
+## Encoding Detection and Conversion
+
+The `detect_and_convert_encoding.py` script is designed to detect the encoding of the `fortran/calculate_emissions.f90` file and convert it to UTF-8 if necessary. This ensures that the file is in the correct encoding format for further processing.
+
+### Running the Script
+
+To run the `detect_and_convert_encoding.py` script, follow these steps:
+
+1. Open a terminal in the devcontainer.
+2. Run the following command to execute the script:
+   ```
+   python detect_and_convert_encoding.py
+   ```
+
+The script will detect the encoding of the `fortran/calculate_emissions.f90` file and convert it to UTF-8 if it is not already in that format. If an error occurs during encoding detection, the script will log the error message to the console and set the default encoding to UTF-8.

--- a/detect_and_convert_encoding.py
+++ b/detect_and_convert_encoding.py
@@ -1,0 +1,34 @@
+import chardet
+
+def detect_and_convert_encoding(file_path):
+    try:
+        # Detect the encoding of the file
+        with open(file_path, "rb") as file:
+            raw_data = file.read()
+            encoding = chardet.detect(raw_data)['encoding']
+
+        print(f"Detected file encoding: {encoding}")
+
+        # Convert to UTF-8 if not already
+        if encoding.lower() != "utf-8":
+            with open(file_path, "r", encoding=encoding) as file:
+                content = file.read()
+
+            with open(file_path, "w", encoding="utf-8") as file:
+                file.write(content)
+
+            print("File converted to UTF-8 encoding.")
+    except Exception as e:
+        print(f"Error detecting encoding: {e}")
+        encoding = "utf-8"
+
+        with open(file_path, "r", encoding=encoding) as file:
+            content = file.read()
+
+        with open(file_path, "w", encoding="utf-8") as file:
+            file.write(content)
+
+        print("File converted to UTF-8 encoding with default encoding.")
+
+if __name__ == "__main__":
+    detect_and_convert_encoding("fortran/calculate_emissions.f90")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,24 @@
+import chardet
 import emissions
 import efficiency
 import tradeoffs
+
+# Detect the encoding of the file
+with open("fortran/calculate_emissions.f90", "rb") as file:
+    raw_data = file.read()
+    encoding = chardet.detect(raw_data)['encoding']
+
+print(f"Detected file encoding: {encoding}")
+
+# Convert to UTF-8 if not already
+if encoding.lower() != "utf-8":
+    with open("fortran/calculate_emissions.f90", "r", encoding=encoding) as file:
+        content = file.read()
+
+    with open("fortran/calculate_emissions.f90", "w", encoding="utf-8") as file:
+        file.write(content)
+
+    print("File converted to UTF-8 encoding.")
 
 co2 = emissions.calculate_emissions(1, 500.0)
 eff = efficiency.optimize_fuel_efficiency(12000.0, 8000.0, 0.6)


### PR DESCRIPTION
Add code to detect and convert file encoding in `main.py`.

* Import `chardet` module at the top of the file.
* Detect the encoding of `fortran/calculate_emissions.f90` file.
* Convert the file to UTF-8 if it is not already in that encoding.
* Print the detected file encoding and a message if the file is converted to UTF-8.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Gaia-Q-Space/.github/pull/4?shareId=f8aa50f7-a002-4385-9c55-9ce9affab20e).